### PR TITLE
feature/notification PR

### DIFF
--- a/src/main/java/pinup/backend/config/SecurityConfig.java
+++ b/src/main/java/pinup/backend/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,7 +16,7 @@ import pinup.backend.member.command.repository.AdminRepository;
 
 @Configuration
 @RequiredArgsConstructor
-public class SecurityConfig {
+public class SecurityConfig{
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomAdminDetailsService customAdminDetailsService;
@@ -70,6 +71,11 @@ public class SecurityConfig {
                         .build());
             }
         };
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/notifications/**");
     }
 
 }

--- a/src/main/java/pinup/backend/notification/controller/NotificationController.java
+++ b/src/main/java/pinup/backend/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package pinup.backend.notification.controller;
 
+import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,14 +10,17 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import pinup.backend.notification.service.NotificationService;
 
+import java.util.concurrent.Executors;
+
 @RestController
 @RequestMapping("/notifications")
 @RequiredArgsConstructor
+@PermitAll
 public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping(value = "/connect/{clientId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter connect(@PathVariable Integer clientId) {
+    public SseEmitter connect(@PathVariable Long clientId) {
         return notificationService.establishConnect(clientId);
     }
 }

--- a/src/main/java/pinup/backend/notification/dto/NotificationRequest.java
+++ b/src/main/java/pinup/backend/notification/dto/NotificationRequest.java
@@ -10,8 +10,12 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class NotificationRequest {
-    private Integer senderId;
-    private Integer receiverId;
-    private String notificationType;
+    private Long senderId;
+    private Long receiverId;
+    private NotificationType notificationType;
     private String notificationMessage;
+
+    public enum NotificationType {
+        FEED_LIKE, BONUS_POINT, SUSPEND, REPORT_HANDLED
+    }
 }

--- a/src/main/java/pinup/backend/notification/service/NotificationService.java
+++ b/src/main/java/pinup/backend/notification/service/NotificationService.java
@@ -13,12 +13,13 @@ import java.util.Map;
 public class NotificationService {
     private final Map<Integer, SseEmitter> sseEmitter;
 
-    public SseEmitter establishConnect(Integer clientId) {
+    public SseEmitter establishConnect(Long clientId) {
         Long connectionTimeout = 60 * 1000L;
+        Integer clientIdInt = clientId.intValue();
 
         SseEmitter emitter = new SseEmitter(connectionTimeout);
 
-        sseEmitter.put(clientId, emitter);
+        sseEmitter.put(clientIdInt, emitter);
 
         emitter.onTimeout(() -> {
             try {
@@ -29,8 +30,8 @@ public class NotificationService {
             emitter.complete();  // 이 호출로 onCompletion() 자동 실행됨
         });
 
-        emitter.onCompletion(() -> sseEmitter.remove(clientId));
-        emitter.onError(e -> sseEmitter.remove(clientId));
+        emitter.onCompletion(() -> sseEmitter.remove(clientIdInt));
+        emitter.onError(e -> sseEmitter.remove(clientIdInt));
 
         try {
             emitter.send(SseEmitter.event().name("connect").data("연결 성공"));
@@ -41,8 +42,9 @@ public class NotificationService {
         return emitter;
     }
 
-    public void sendNotification(Integer clientId, NotificationRequest notificationRequest) {
-        SseEmitter emitter = sseEmitter.get(clientId);
+    public void sendNotification(Long clientId, NotificationRequest notificationRequest) {
+        Integer clientIdInt = clientId.intValue();
+        SseEmitter emitter = sseEmitter.get(clientIdInt);
 
         if (emitter != null) {
             try {
@@ -51,7 +53,7 @@ public class NotificationService {
                         .data(notificationRequest));
             }
             catch (IOException e) {
-                sseEmitter.remove(clientId);
+                sseEmitter.remove(clientIdInt);
                 emitter.completeWithError(e);
             }
         }


### PR DESCRIPTION
### 알림 기능 구현을 위한 sse 관련 기능 추가
- 향후 frontend단에서 사용될 sse connection 수립 엔드포인트 구현
- sse emitter에 data를 송신하기 위한 method 구현
- SecurityFilterChain이 sse connection을 filtering하던 버그 수정

### 이후 할 일
- 알림 송신이 실제로 필요한 메소드에 (피드 좋아요, 사용자 정지, 포인트 획득 등) sendNotification 메소드를 호출하여 data를 송신하도록 현해줘야함 (아래 예시)

```
private final NotificationService notificationService; // NotificationService 주입 받음

    // 회원 정지
    public void suspendUser(Long id) {
        Users user = memberCommandRepository.findById(Long.valueOf(id))
                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));

        /*
         * sendNotification이라는 메소드 활용하여 알림 송신
         * sendNotification({알람받을 유저 id}, {알림 내용 dto})
        */

        notificationService.sendNotification(id, NotificationRequest.builder()
                .senderId(null)
                .receiverId(null)
                .notificationType(NotificationRequest.NotificationType.SUSPEND)
                .notificationMessage("당신은 활동 정지 되었습니다.")
                .build()); 
        
        user.suspend(); // Users 엔티티에 정의된 메서드
    }
```